### PR TITLE
new msgpack spec compatibility

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
   "name": "msgpack-js",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "A msgpack encoder and decoder using ArrayBuffer and DataView",
   "main": "msgpack.js",
   "scripts": ["msgpack.js"]

--- a/msgpack.js
+++ b/msgpack.js
@@ -470,7 +470,7 @@ function encode(value, view, offset) {
     return 3;
   }
   
-  // null, undefined
+  // null
   if (value === null) {
     view.setUint8(offset, 0xc0);
     return 1;

--- a/msgpack.js
+++ b/msgpack.js
@@ -331,7 +331,7 @@ function decode(buffer) {
   var view = new DataView(buffer);
   var decoder = new Decoder(view);
   var value = decoder.parse();
-  // if (decoder.offset !== buffer.byteLength) throw new Error((buffer.byteLength - decoder.offset) + " trailing bytes");
+  if (decoder.offset !== buffer.byteLength) throw new Error((buffer.byteLength - decoder.offset) + " trailing bytes");
   return value;
 }
 

--- a/msgpack.js
+++ b/msgpack.js
@@ -369,7 +369,7 @@ function encode(value, view, offset) {
       view.setUint8(offset, 0xc4);
       view.setUint8(offset + 1, length);
       (new Uint8Array(view.buffer)).set(new Uint8Array(value), offset + 2);
-      return 3 + length;
+      return 2 + length;
     }
     // bin 16
     if (length < 0x10000) {
@@ -382,7 +382,6 @@ function encode(value, view, offset) {
     if (length < 0x100000000) {
       view.setUint8(offset, 0xc6);
       view.setUint32(offset + 1, length);
-      utf8Write(view, offset + 5, value);
       (new Uint8Array(view.buffer)).set(new Uint8Array(value), offset + 5);
       return 5 + length;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msgpack-js-browser",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "description": "A msgpack encoder and decoder using ArrayBuffer and DataView",
   "main": "msgpack.js",
   "licenses": [


### PR DESCRIPTION
Hi Tim,

The msgpack spec added a Bin type and got an updated spec back in August 2013. I'd like to update the msgpack.js encoder and decoder to support the new spec.

Unfortunately, some of the existing extensions used reserved data type which are part of the new spec:
* `0xc4` (previously encoded `undefined`) is now specced as `bin 8`
* `0xd8` (previously a buffer type) is now specced as `fixext 16`
* `0xd9` (previously a buffer type) is now specced as `str 8`

I've had to change the encoding/decoding which breaks backwards-compatibility with previous msgpack-js encoded data if they used the reserved types.

Do you think we can merge this change to be compatible with the updated spec? Any suggestions on how to handle backwards compatibility with the js-specific extensions?

~Ambrus
