### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,16 @@ The original format can be found at <http://wiki.msgpack.org/display/MSGPACK/For
 
 ## Extension
 
-I've extended the format a little to allow for encoding and decoding of `undefined` and `ArrayBuffer` instances.
+I've extended the format a little to allow for encoding and decoding of `undefined`.
 
-This required three new type codes that were previously marked as "reserved".
+This required a new type code that is marked as "ext format".
 This change means that using these new types will render your serialized data
 incompatible with other messagepack implementations that don't have the same
 extension.
 
-There are two new types for storing browser `ArrayBuffer` instances. These work just 
-like "raw 16" and "raw 32" except they are binary buffers instead of strings.
+I've added a type for `undefined` that works just like the `null` type.
 
-    buffer 16  11011000  0xd8
-    buffer 32  11011001  0xd9
-
-Also I've added a type for `undefined` that works just like the `null` type.
-
-    undefined  11000100  0xc4
+    undefined  11010100  0xd4
 
 ## Usage
 


### PR DESCRIPTION
Update readme.md since it looks the library supports msgpack v5 spec and has only one extension for `undefined` now.
