### PR TITLE
Fixed Bug in Double Byte Code in utf8Read

### DIFF
--- a/msgpack.js
+++ b/msgpack.js
@@ -89,7 +89,7 @@ function utf8Read(view, offset, length) {
     // Two byte character
     if ((byte & 0xe0) === 0xc0) {
       string += String.fromCharCode(
-        ((byte & 0x0f) << 6) |
+        ((byte & 0x1f) << 6) |
         (view.getUint8(++i) & 0x3f)
       );
       continue;


### PR DESCRIPTION
Code before fix was extracting 4-bits from 1st utf8 Byte instead of 5 bits, resulting in 10-bit binary number instead of 11-bit as specified for Double Byte  

Changed 0xf to 0x1f